### PR TITLE
Add search_test_element helper

### DIFF
--- a/lib/test_selector/html_helpers.ex
+++ b/lib/test_selector/html_helpers.ex
@@ -28,7 +28,7 @@ defmodule TestSelector.HTML.Helpers do
         |> String.trim_trailing("View")
         |> String.trim_trailing("Cell")
         |> String.downcase()
-        |> Kernel.<>("-#{test_hash()}")
+        |> Kernel.<>("-#{test_selector_hash()}")
       end
 
       @doc """
@@ -38,12 +38,14 @@ defmodule TestSelector.HTML.Helpers do
           "user-45e6f-avatar"
       """
       def test_selector(name) do
-        test_selector()
-        |> Kernel.<>("-#{name}")
+        case name do
+          nil -> nil
+          _   -> test_selector() <> "-#{name}"
+        end
       end
 
       @doc """
-      The test function will return both the HTML attribute and it's value
+      The test function will return both the HTML attribute and it's value.
       ## Examples
 
           iex()> UserCell.test()
@@ -60,8 +62,9 @@ defmodule TestSelector.HTML.Helpers do
         test_selector()
         |> test_attributes()
       end
+
       @doc """
-      The test function will return both the HTML attribute and it's value
+      The test function will return both the HTML attribute and it's value.
       ## Examples
 
       With just a name
@@ -88,7 +91,10 @@ defmodule TestSelector.HTML.Helpers do
         |> test_attributes(value)
       end
 
-      def test_hash do
+      @doc """
+      It returns the a hash of the module.
+      """
+      def test_selector_hash do
         :md5
         |> :crypto.hash("#{__MODULE__}")
         |> Base.encode16(case: :lower)
@@ -102,14 +108,17 @@ defmodule TestSelector.HTML.Helpers do
     end
   end
 
-
+  @doc false
   def test_attributes(selector) do
     output_attributes(HTML.raw(~s(test-selector="#{selector}")))
   end
+  @doc false
   def test_attributes(selector, nil), do: test_attributes(selector)
+  @doc false
   def test_attributes(selector, value) do
     output_attributes(HTML.raw(~s(test-selector="#{selector}" test-value="#{value}")))
   end
+
   defp output_attributes(attributes) do
     case Mix.env do
       :prod -> ""

--- a/lib/test_selector/test_helpers.ex
+++ b/lib/test_selector/test_helpers.ex
@@ -1,30 +1,64 @@
 defmodule TestSelector.Test.Helpers do
   @moduledoc """
-  Test Helpers
+  Test Helpers.
   """
-
   use Hound.Helpers
 
+  @doc """
+  Finds element by test selector on current page.
+  It returns an element that can be used with other element functions.
+  """
   def find_test_element(view_module) do
     {:safe, test_selector} = view_module.test()
-    find_element(:xpath, ~s|//*[@#{test_selector}]|)
+    find_element(:xpath, ~s|#{xpath_pattern(test_selector)}|)
+  end
+  def find_test_element(view_module, selector) do
+    {:safe, test_selector} = view_module.test(selector)
+    find_element(:xpath, ~s|#{xpath_pattern(test_selector)}|)
+  end
+  def find_test_element(view_module, selector, value) do
+    {:safe, test_selector} = view_module.test(selector)
+    find_element(:xpath, ~s|#{xpath_pattern(test_selector, value)}|)
   end
 
-  def find_test_element(view_module, name) do
-    {:safe, test_selector} = view_module.test(name)
-    find_element(:xpath, ~s|//*[@#{test_selector}]|)
+  @doc """
+  Same as `find_test_element`, but returns the a tuple with `{:error, error}` instead of raising.
+  """
+  def search_test_element(view_module) do
+    {:safe, test_selector} = view_module.test()
+    search_element(:xpath, ~s|#{xpath_pattern(test_selector)}|)
+  end
+  def search_test_element(view_module, selector) do
+    {:safe, test_selector} = view_module.test(selector)
+    search_element(:xpath, ~s|#{xpath_pattern(test_selector)}|)
+  end
+  def search_test_element(view_module, selector, value) do
+    {:safe, test_selector} = view_module.test(selector)
+    search_element(:xpath, ~s|#{xpath_pattern(test_selector, value)}|)
   end
 
-  def find_test_element(view_module, name, value) do
-    {:safe, test_selector} = view_module.test(name)
-    find_element(:xpath, ~s|//*[@#{test_selector}][@test-value="#{value}"]|)
-  end
-
-  def test_element_value(%Hound.Element{} = element) do
+  @doc """
+  Get an element `test-value` attribute.
+  It returns `nil` then the `test-value` attribute is not found.
+  """
+  def element_test_value(%Hound.Element{} = element) do
     attribute_value(element, "test-value")
   end
 
-  def test_element_value?(%Hound.Element{} = element, value) do
-    test_element_value(element) == to_string(value)
+  @doc """
+  Check if the element `test-value` attribute matches the given value.
+
+  * It returns `true` if the value matches.
+  * It returns `false` if the value does not match or is not found.
+  """
+  def element_test_value?(%Hound.Element{} = element, value) do
+    element_test_value(element) == to_string(value)
+  end
+
+  # Get test attributes xpath pattern
+  defp xpath_pattern(selector), do: "//*[@#{selector}]"
+  defp xpath_pattern(selector, nil), do: xpath_pattern(selector)
+  defp xpath_pattern(selector, value) do
+    xpath_pattern(selector) <> "[@test-value=\"#{value}\"]"
   end
 end

--- a/test/html_helpers_test.exs
+++ b/test/html_helpers_test.exs
@@ -14,25 +14,3 @@ defmodule TestSelector.HTML.HelpersTest do
     assert UserView.test_selector("avatar") =~ ~s(avatar)
   end
 end
-
-defmodule TestSelector.Test.HelpersTest do
-  use ExUnit.Case
-  use Hound.Helpers
-
-  alias TestSelector.Support.UserView
-  import TestSelector.Test.Helpers
-
-  hound_session()
-
-  test "find a specific user with find_test_element/3" do
-    navigate_to "http://localhost:9090/index.html"
-
-    assert find_test_element(UserView, "user-list-item", "6") |> inner_text() =~ "right user"
-  end
-
-  test "find the avatar text with find_test_element/2" do
-    navigate_to "http://localhost:9090/index.html"
-
-    assert find_test_element(UserView, "avatar") |> inner_text() == "avatar"
-  end
-end

--- a/test/test_helpers_test.exs
+++ b/test/test_helpers_test.exs
@@ -1,0 +1,33 @@
+defmodule TestSelector.Test.HelpersTest do
+  use ExUnit.Case
+  use Hound.Helpers
+  alias TestSelector.Support.UserView
+  import TestSelector.Test.Helpers
+
+  hound_session()
+
+  test "find the avatar text using find_test_element/2" do
+    navigate_to "http://localhost:9090/index.html"
+    assert find_test_element(UserView, "avatar") |> inner_text() == "avatar"
+  end
+
+  test "find a specific user using find_test_element/3" do
+    navigate_to "http://localhost:9090/index.html"
+    assert find_test_element(UserView, "user-list-item", 6) |> inner_text() =~ "right user"
+  end
+
+  test "search for the avatar element using search_test_element/2" do
+    navigate_to "http://localhost:9090/index.html"
+    assert {:ok, %Hound.Element{}} = search_test_element(UserView, "avatar")
+  end
+
+  test "search for specific user element using search_test_element/3" do
+    navigate_to "http://localhost:9090/index.html"
+    assert {:ok, %Hound.Element{}} = search_test_element(UserView, "user-list-item", 6)
+  end
+
+  test "search for an element that does not exist using search_test_element/2" do
+    navigate_to "http://localhost:9090/index.html"
+    assert search_test_element(UserView, "does-not-exist") == {:error, :no_such_element}
+  end
+end


### PR DESCRIPTION
Add `search_test_element` helper. Same behaviour as find_test_element, but returns the a tuple with {:error, error} instead of raising.

```ex
assert search_test_element(MainNavigationCell, "does_not_exist") == {:error, :no_such_element}
```

- [x] Add helper
- [x] Add docs
- [x] Add tests
