### PR TITLE
Remove () from iex examples

### DIFF
--- a/lib/test_selector/html_helpers.ex
+++ b/lib/test_selector/html_helpers.ex
@@ -34,13 +34,13 @@ defmodule TestSelector.HTML.Helpers do
       @doc """
       ## Example
 
-          iex()> UserCell.test_selector("avatar")
+          iex> UserCell.test_selector("avatar")
           "user-45e6f-avatar"
       """
       def test_selector(name) do
         case name do
           nil -> nil
-          _   -> test_selector() <> "-#{name}"
+          _ -> test_selector() <> "-#{name}"
         end
       end
 
@@ -48,7 +48,7 @@ defmodule TestSelector.HTML.Helpers do
       The test function will return both the HTML attribute and it's value.
       ## Examples
 
-          iex()> UserCell.test()
+          iex> UserCell.test()
           "test-selector=\"user-45e6f\""
 
       In the user show template:
@@ -69,12 +69,12 @@ defmodule TestSelector.HTML.Helpers do
 
       With just a name
 
-          iex()> UserCell.test("avatar")
+          iex> UserCell.test("avatar")
           "test-selector=\"user-45e6f-avatar\""
 
       With both a name and value
 
-          iex()> UserCell.test("id", 13)
+          iex> UserCell.test("id", 13)
           "test-selector=\"user-45e6f-id\" test-value=\"13\""
 
       In the user show template:
@@ -101,10 +101,8 @@ defmodule TestSelector.HTML.Helpers do
         |> String.slice(0, 5)
       end
 
-      defoverridable [
-        test_selector: 0,
-        test_selector: 1
-      ]
+      defoverridable test_selector: 0,
+                     test_selector: 1
     end
   end
 
@@ -112,6 +110,7 @@ defmodule TestSelector.HTML.Helpers do
   def test_attributes(selector) do
     output_attributes(HTML.raw(~s(test-selector="#{selector}")))
   end
+
   @doc false
   def test_attributes(selector, nil), do: test_attributes(selector)
   @doc false
@@ -120,7 +119,7 @@ defmodule TestSelector.HTML.Helpers do
   end
 
   defp output_attributes(attributes) do
-    case Mix.env do
+    case Mix.env() do
       :prod -> ""
       _ -> attributes
     end

--- a/lib/test_selector/html_helpers.ex
+++ b/lib/test_selector/html_helpers.ex
@@ -113,7 +113,6 @@ defmodule TestSelector.HTML.Helpers do
 
   @doc false
   def test_attributes(selector, nil), do: test_attributes(selector)
-  @doc false
   def test_attributes(selector, value) do
     output_attributes(HTML.raw(~s(test-selector="#{selector}" test-value="#{value}")))
   end


### PR DESCRIPTION
They cause errors when running doctests for views that use this module.