### PR TITLE
fix typo and try `find_test_selector!`

### DIFF
--- a/lib/test_selector/test/floki_helpers.ex
+++ b/lib/test_selector/test/floki_helpers.ex
@@ -53,7 +53,7 @@ defmodule TestSelector.Test.FlokiHelpers do
 
   @doc """
   Same as `find_test_selectors/2`, but instead of returning a list of elements only
-  the first elements is returned.
+  the first element is returned.
 
   ## Examples
 
@@ -76,7 +76,7 @@ defmodule TestSelector.Test.FlokiHelpers do
 
   @doc """
   Same as `find_test_selectors/3`, but instead of returning a list of elements only
-  the first elements is returned.
+  the first element is returned.
 
   ## Examples
 
@@ -140,7 +140,7 @@ defmodule TestSelector.Test.FlokiHelpers do
 
   @doc """
   Same as `find_test_values/2`, but instead of returning a list of elements only
-  the first elements is returned.
+  the first element is returned.
 
   ## Examples
 

--- a/lib/test_selector/test/floki_helpers.ex
+++ b/lib/test_selector/test/floki_helpers.ex
@@ -99,6 +99,35 @@ defmodule TestSelector.Test.FlokiHelpers do
     do: input |> find_test_selectors(selector, value) |> List.first()
 
   @doc """
+  Same as `find_test_selector/2, except it will raise if either none or multiple
+  `test-selectors` are found.
+
+  ## Examples
+
+      iex> text = ~S(<a test-selector="hello" test-value="world"></a><a test-selector="foo" test-value="bar"></a>)
+      iex> find_test_selector!(text, "hello")
+      {"a", [{"test-selector", "hello"}, {"test-value", "world"}], []}
+
+      iex> tree = [{"a", [{"test-selector", "hello"}, {"test-value", "world"}], []}, {"a", [{"test-selector", "foo"}, {"test-value", "bar"}], []}]
+      iex> find_test_selector!(tree, "foo")
+      {"a", [{"test-selector", "foo"}, {"test-value", "bar"}], []}
+
+      iex> text = ~S(<a test-selector="hello" test-value="world"></a>)
+      iex> find_test_selector!(text, "foo")
+      ** (RuntimeError) Multiple elements or none were found
+
+  """
+  @spec find_test_selector!(String.t() | Floki.html_tree(), String.t()) :: Floki.html_tree()
+  def find_test_selector!(input, selector) do
+    element = find_test_selector(input, selector)
+
+    cond do
+      is_list(element) || is_nil(element) -> raise("Multiple elements or none were found")
+      true -> element
+    end
+  end
+
+  @doc """
   Returns a list of test values from given elements.
 
   ## Examples


### PR DESCRIPTION
Not sure if this is something we want, just thinking out loud. But I kind of dislike the function (or maybe the function name) `find_test_selector` as opposed to `find_test_selectors`. 

With `find_test_selectors` we find one or more elements
With `find_test_selector` we find one or more elements and select the first from it

Maybe rename the latter to `(find_)first_test_selector`?