### PR TITLE
raise when conn is supplied as first argument

### DIFF
--- a/lib/test_selector/test/floki_helpers.ex
+++ b/lib/test_selector/test/floki_helpers.ex
@@ -5,6 +5,7 @@ defmodule TestSelector.Test.FlokiHelpers do
 
   @doc """
   Returns a list of elements by a given `test-selector` inside a string or HTML tree.
+  It will raise with an error if a conn is supplied as first argument.
 
   ## Examples
 
@@ -22,6 +23,9 @@ defmodule TestSelector.Test.FlokiHelpers do
 
   """
   @spec find_test_selectors(String.t() | Floki.html_tree(), String.t()) :: Floki.html_tree()
+  def find_test_selectors(%Plug.Conn{}, _),
+    do: raise("use html_response/2 to supply the html to find_test_selectors")
+
   def find_test_selectors(string, selector) when is_binary(string),
     do: string |> Floki.parse_fragment!() |> find_test_selectors(selector)
 
@@ -30,6 +34,7 @@ defmodule TestSelector.Test.FlokiHelpers do
 
   @doc """
   Returns a list of elements by a given `test-selector` and `test-value` inside a string or HTML tree.
+  It will raise with an error if a conn is supplied as first argument.
 
   ## Examples
 
@@ -48,12 +53,17 @@ defmodule TestSelector.Test.FlokiHelpers do
   """
   @spec find_test_selectors(String.t() | Floki.html_tree(), String.t(), String.t()) ::
           Floki.html_tree()
+
+  def find_test_selectors(%Plug.Conn{}, _, _),
+    do: raise("use html_response/2 to supply the html to find_test_selectors")
+
   def find_test_selectors(input, selector, value),
     do: input |> find_test_selectors(selector) |> find_test_values(value)
 
   @doc """
   Same as `find_test_selectors/2`, but instead of returning a list of elements only
   the first elements is returned.
+  It will raise with an error if a conn is supplied as first argument.
 
   ## Examples
 
@@ -71,12 +81,16 @@ defmodule TestSelector.Test.FlokiHelpers do
 
   """
   @spec find_test_selector(String.t() | Floki.html_tree(), String.t()) :: Floki.html_tree() | nil
+  def find_test_selector(%Plug.Conn{}, _),
+    do: raise("use html_response/2 to supply the html to find_test_selector")
+
   def find_test_selector(input, selector),
     do: input |> find_test_selectors(selector) |> List.first()
 
   @doc """
   Same as `find_test_selectors/3`, but instead of returning a list of elements only
   the first elements is returned.
+  It will raise with an error if a conn is supplied as first argument.
 
   ## Examples
 
@@ -95,6 +109,10 @@ defmodule TestSelector.Test.FlokiHelpers do
   """
   @spec find_test_selector(String.t() | Floki.html_tree(), String.t(), String.t()) ::
           Floki.html_tree() | nil
+
+  def find_test_selector(%Plug.Conn{}, _, _),
+    do: raise("use html_response/2 to supply the html to find_test_selector")
+
   def find_test_selector(input, selector, value),
     do: input |> find_test_selectors(selector, value) |> List.first()
 

--- a/test/floki_helpers_test.exs
+++ b/test/floki_helpers_test.exs
@@ -1,5 +1,47 @@
-defmodule DetroitWeb.FlokiHelpersTest do
+defmodule TestSelector.FlokiHelpersTest do
   use ExUnit.Case
 
+  import TestSelector.Test.FlokiHelpers
+
   doctest TestSelector.Test.FlokiHelpers, import: true
+
+  describe "#find_test_selectors/2" do
+    test "raises an error when the conn is given as first argument" do
+      assert_raise(
+        RuntimeError,
+        "use html_response/2 to supply the html to find_test_selectors",
+        fn -> find_test_selectors(%Plug.Conn{}, "selector") end
+      )
+    end
+  end
+
+  describe "#find_test_selectors/3" do
+    test "raises an error when the conn is given as first argument" do
+      assert_raise(
+        RuntimeError,
+        "use html_response/2 to supply the html to find_test_selectors",
+        fn -> find_test_selectors(%Plug.Conn{}, "selector", "value") end
+      )
+    end
+  end
+
+  describe "#find_test_selector/2" do
+    test "raises an error when the conn is given as first argument" do
+      assert_raise(
+        RuntimeError,
+        "use html_response/2 to supply the html to find_test_selector",
+        fn -> find_test_selector(%Plug.Conn{}, "selector") end
+      )
+    end
+  end
+
+  describe "#find_test_selector/3" do
+    test "raises an error when the conn is given as first argument" do
+      assert_raise(
+        RuntimeError,
+        "use html_response/2 to supply the html to find_test_selector",
+        fn -> find_test_selector(%Plug.Conn{}, "selector", "value") end
+      )
+    end
+  end
 end


### PR DESCRIPTION
Because we expect html as input and therefore it won't successfully work
with a supplied conn.

This commit adds a pattern match on the find_test_selectors for conn and
when it matches it will raise an error.