### PR TITLE
Remove Mix calls from lib

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,4 +26,6 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-if (Mix.env == "test"), do: import_config "test.exs"
+config :test_selector, prod_env: Mix.env() == :prod
+
+if Mix.env() == :test, do: import_config("test.exs")

--- a/lib/test_selector/html_helpers.ex
+++ b/lib/test_selector/html_helpers.ex
@@ -118,10 +118,6 @@ defmodule TestSelector.HTML.Helpers do
     output_attributes(HTML.raw(~s(test-selector="#{selector}" test-value="#{value}")))
   end
 
-  defp output_attributes(attributes) do
-    case Mix.env() do
-      :prod -> ""
-      _ -> attributes
-    end
-  end
+  defp output_attributes(attributes),
+    do: if(Application.get_env(:test_selector, :prod_env), do: "", else: attributes)
 end


### PR DESCRIPTION
We can't use Mix.env() when using Elixir releases, this PR removes a Mix.env() call that can give errors when running a release app.